### PR TITLE
Build cc65 internally, to reduce dependency count and work out which version of vivado you have automatically

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/mega65-fdisk"]
 	path = src/mega65-fdisk
 	url = https://github.com/MEGA65/mega65-fdisk.git
+[submodule "cc65"]
+	path = cc65
+	url = https://github.com/cc65/cc65.git

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ OPHIS=	../Ophis/bin/ophis -4
 
 VIVADO=	./vivado_wrapper
 
-CA65=  ca65 --cpu 4510
-LD65=  ld65 -t none
+CA65=  cc65/bin/ca65 --cpu 4510
+LD65=  cc65/bin/ld65 -t none
 
 ASSETS=		assets
 SRCDIR=		src
@@ -65,6 +65,10 @@ all:	$(SDCARD_DIR)/MEGA65.D81 $(BINDIR)/mega65r1.mcs $(BINDIR)/nexys4.mcs $(BIND
 
 generated_vhdl:	$(SIMULATIONVHDL)
 
+$(CA65):
+	git submodule init
+	git submodule update
+	( cd cc65 ; make )
 
 # files destined to go on the SD-card to serve as firmware for the MEGA65
 firmware:	$(SDCARD_DIR)/BANNER.M65 \

--- a/vivado_wrapper
+++ b/vivado_wrapper
@@ -1,4 +1,5 @@
 #!/bin/bash
-. /opt/Xilinx/Vivado/2017.4/settings64.sh
+vver=`( cd /opt/Xilinx/Vivado/ ; ls | tail -1)`
+. /opt/Xilinx/Vivado/${vver}/settings64.sh
 echo vivado $*
 vivado $*


### PR DESCRIPTION
These two commits were prepared with Paul to make it easier to get started with MEGA65 development.  There are other dependencies that have not been tackled yet, but this is a start.